### PR TITLE
Support better FetchContent-based workflow

### DIFF
--- a/src/RobotsViz/CMakeLists.txt
+++ b/src/RobotsViz/CMakeLists.txt
@@ -18,7 +18,9 @@ find_package(Eigen3 REQUIRED)
 find_package(OpenCV REQUIRED)
 
 # RobotsIO
-find_package(RobotsIO REQUIRED)
+if (NOT TARGET RobotsIO::RobotsIO)
+  find_package(RobotsIO REQUIRED)
+endif()
 
 # VTK
 find_package(VTK REQUIRED)
@@ -161,6 +163,7 @@ cmrc_add_resource_library(${LIBRARY_TARGET_NAME}_RCShader
 
 # Create library
 add_library(${LIBRARY_TARGET_NAME} ${${LIBRARY_TARGET_NAME}_SRC} ${${LIBRARY_TARGET_NAME}_HDR})
+add_library(${PROJECT_NAME}::${LIBRARY_TARGET_NAME} ALIAS ${LIBRARY_TARGET_NAME})
 
 target_include_directories(${LIBRARY_TARGET_NAME}
                            PUBLIC


### PR DESCRIPTION
Changes:
 * Add alias (see https://github.com/robotology/how-to-export-cpp-library/blob/afb21efb655e7b1cc11636c3d42aad9e02fb626f/src/LibTemplateCMake/CMakeLists.txt#L55)
 * Permit to use RobotsIO if it is present in the build via `FetchContent` (depends on https://github.com/xEnVrE/robots-io/pull/3)

This two changes would permit to use robots-viz and robots-io in a package by calling FetchContent for both of them one after the other.



